### PR TITLE
Adding the missing placeholder for translationProgress

### DIFF
--- a/en_US/messages.json
+++ b/en_US/messages.json
@@ -127,6 +127,12 @@
     },
     "translationProgress": {
       "message": "Elements pending to translate: $ELEMENTSPENDING$",
-      "description": "Number of elements still pending to be translated by the engine."
+      "description": "Number of elements still pending to be translated by the engine.",
+      "placeholders": {
+        "elementspending" : {
+          "content" : "$1",
+          "example" : "100"
+        }
+      }
     }
 }


### PR DESCRIPTION
I missed the placeholder entry for that message. I hope this doesn't trigger requests for translations to all localizers again.