### PR TITLE
Change quality estimation message

### DIFF
--- a/en_US/messages.json
+++ b/en_US/messages.json
@@ -79,10 +79,6 @@
       "message": "Enable translations of forms",
       "description": "Checkbox to enable the translation of forms."
     },
-    "qualityEstimationMessage": {
-      "message": "Enable quality estimation",
-      "description":"Checkbox to enable the quality estimation of the translation."
-    },
     "formtranslationsReady": {
       "message": "Ready",
       "description":"Notifies that the form translation is ready to be used."
@@ -154,5 +150,9 @@
     "datacollectionConsentPageErrorsOption": {
       "message": "Report errors",
       "description": "Title for the option that allows Mozilla to collect error reports"
+    },
+    "errorHighlightingMessage": {
+      "message": "Highlight potential errors in red",
+      "description":"Checkbox to highlight translation errors in the page in red."
     }
 }


### PR DESCRIPTION
fixes https://github.com/mozilla/firefox-translations/issues/326

@flodolo I'm not sure if this is the best way to replace the messages, but we need to change it per this comment: https://github.com/mozilla/firefox-translations/issues/326#issuecomment-1131510640
Thank you.